### PR TITLE
remove justify-content property to fix layout

### DIFF
--- a/budgetplanner/static/css/sb_admin.css
+++ b/budgetplanner/static/css/sb_admin.css
@@ -11317,7 +11317,6 @@ body {
   position: relative;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
   min-width: 0;
   flex-grow: 1;
   min-height: calc(100vh - 56px);


### PR DESCRIPTION
I found the issue was the justify content property that creates a space once the messages appear. Two other fixes I can think for this issue are to remove flexbox, or to the make the messages' position absolute so that it doesn't appear with the document's flow. 

![Screenshot 2024-01-20 at 12 56 20](https://github.com/JesseRoss001/janhackathonteam11/assets/57060620/b7284a35-bf3c-42ad-8f65-ea849a089d6d)
